### PR TITLE
Fixes for proper packaging

### DIFF
--- a/cmsplugin_carousel_ai/cms_plugins.py
+++ b/cmsplugin_carousel_ai/cms_plugins.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
-
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+from django.contrib import admin
+from django.utils.translation import ugettext_lazy as _
 
 from .models import Carousel, Slide
 

--- a/cmsplugin_carousel_ai/models.py
+++ b/cmsplugin_carousel_ai/models.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
+from cms.models import CMSPlugin, force_text, Page
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
-from cms.models import CMSPlugin, Page, force_text
 from filer.fields.image import FilerImageField
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
+autoflake
+autopep8
 flake8
+isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 [pep8]
 max-line-length = 120
 exclude=.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
+
+[bdist_wheel]
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,17 @@ exclude=.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 
 [bdist_wheel]
 universal = 1
+
+[isort]
+atomic = true
+combine_as_imports = false
+indent = 4
+known_standard_library = token,tokenize,enum,importlib
+known_third_party = django,six
+length_sort = false
+line_length = 120
+multi_line_output = 5
+not_skip = __init__.py
+order_by_type = false
+skip = migrations
+wrap_length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from distutils.core import setup
-
+from setuptools import setup
 
 setup(
     name='cmsplugin-carousel-ai',


### PR DESCRIPTION
- 👉  `distutils` shouldn't be used anymore; `setuptools` has the right stuff
- 👉  universal wheels mean that `.whl`s should work on both Py2 and Py3 (though we don't have tests to verify that just yet)
- 👉  import order, man
